### PR TITLE
fix: improve responsiveness of is_connected()

### DIFF
--- a/src/page_explorer/page_explorer.py
+++ b/src/page_explorer/page_explorer.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any, Callable
 
 from selenium.common.exceptions import (
     ElementNotInteractableException,
+    NoSuchWindowException,
     StaleElementReferenceException,
     WebDriverException,
 )
@@ -292,16 +293,16 @@ class PageExplorer:
         return PageLoad.FAILURE
 
     def is_connected(self) -> bool:
-        """Check if a page is open and connection is active.
+        """Check if the browser is running and the connection is active.
 
         Args:
             None
 
         Returns:
-            True if a page is open and connection is active otherwise False.
+            True if connected to the browser otherwise False.
         """
-        with suppress(HTTPError, WebDriverException):
-            return isinstance(self._driver.title, str)
+        with suppress(HTTPError, NoSuchWindowException, WebDriverException):
+            return isinstance(self._driver.current_window_handle, str)
         return False
 
     def shutdown(self) -> None:

--- a/src/page_explorer/test_page_explorer.py
+++ b/src/page_explorer/test_page_explorer.py
@@ -41,18 +41,20 @@ def test_page_explorer_create(mocker, exc):
 
 
 @mark.parametrize(
-    "title_effect, result",
+    "cwh_effect, result",
     (
         # connected
-        (("foo",), True),
+        (("ef101f53-3f1f-4c20-9d6c-98912d9d72f3",), True),
         # not connected
         ((WebDriverException("test"),), False),
     ),
 )
-def test_page_explorer_is_connected(mocker, title_effect, result):
+def test_page_explorer_is_connected(mocker, cwh_effect, result):
     """test PageExplorer.is_connected()"""
     driver = mocker.patch("page_explorer.page_explorer.FirefoxDriver", autospec=True)
-    type(driver.return_value).title = mocker.PropertyMock(side_effect=title_effect)
+    type(driver.return_value).current_window_handle = mocker.PropertyMock(
+        side_effect=cwh_effect
+    )
 
     with PageExplorer("bin", 1234) as exp:
         assert exp.is_connected() == result
@@ -77,7 +79,7 @@ def test_page_explorer_current_url(mocker, url_effect, result):
 
 
 @mark.parametrize(
-    "title_calls, title_effect, script_effect",
+    "cwh_calls, cwh_effect, script_effect",
     (
         # wait until deadline is exceeded
         (4, repeat("foo"), None),
@@ -87,7 +89,7 @@ def test_page_explorer_current_url(mocker, url_effect, result):
         (0, (AssertionError("test failed"),), (WebDriverException("test"),)),
     ),
 )
-def test_page_explorer_close_browser(mocker, title_calls, title_effect, script_effect):
+def test_page_explorer_close_browser(mocker, cwh_calls, cwh_effect, script_effect):
     """test PageExplorer.close_browser()"""
     mocker.patch("page_explorer.page_explorer.perf_counter", side_effect=count())
     mocker.patch("page_explorer.page_explorer.sleep", autospec=True)
@@ -95,13 +97,13 @@ def test_page_explorer_close_browser(mocker, title_calls, title_effect, script_e
         "page_explorer.page_explorer.FirefoxDriver", autospec=True
     ).return_value
 
-    fake_title = mocker.PropertyMock(side_effect=title_effect)
-    type(driver).title = fake_title
+    fake_current_window_handle = mocker.PropertyMock(side_effect=cwh_effect)
+    type(driver).current_window_handle = fake_current_window_handle
     driver.execute_script.side_effect = script_effect
     with PageExplorer("bin", 1234) as exp:
         exp.close_browser(wait=5)
     assert driver.execute_script.call_count == 1
-    assert fake_title.call_count == title_calls
+    assert fake_current_window_handle.call_count == cwh_calls
 
 
 @mark.parametrize(


### PR DESCRIPTION
Using driver.current_window_handle instead of driver.title improves performance under load. This is helpful when loading a busy page and using using rr.